### PR TITLE
Don't run post_install twice

### DIFF
--- a/lua/user/packman.lua
+++ b/lua/user/packman.lua
@@ -137,7 +137,6 @@ function PackMan:request(pack)
   if self.parallel then
     self.packadd_queue:push_back(pack)
   else
-    post_install(pack)
     packadd(pack)
     if pack.config then pack.config() end
   end


### PR DESCRIPTION
The last line in PackMan:install already runs post_install, when not in parallel mode.  Further if the package is already installed this line runs post_install.